### PR TITLE
adds Krea2 model and workflow with good starter settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1364,27 +1364,9 @@ class UntwistingRoPE:
                     'step': 0.01,
                     'tooltip': 'AdaIN aligns the target style statistics toward the reference.'
                 }),
-                'block_start': ('INT', {
-                    'default': 0,
-                    'min': 0,
-                    'max': 999,
-                    'step': 1,
-                    'tooltip': 'First block to patch (inclusive). Used when blocks string is empty.',
-                }),
-                'block_end': ('INT', {
-                    'default': 999,
-                    'min': 0,
-                    'max': 999,
-                    'step': 1,
-                    'tooltip': 'Last block to patch (inclusive). Used when blocks string is empty.',
-                }),
                 'blocks': ('STRING', {
-                    'default': '',
-                    'tooltip': (
-                        'Optional block range override, e.g. "7-27" or "0-8, 20-27". '
-                        'If non-empty, overrides block_start and block_end. '
-                        'If empty, block_start and block_end are used.'
-                    ),
+                    'default': '0-999',
+                    'tooltip': 'Specify block ranges to patch, e.g -> 0-8, 28-37'
                 }),
                 'verbose': ('BOOLEAN', {
                     'default': False,
@@ -1393,14 +1375,6 @@ class UntwistingRoPE:
             },
             'optional': {
                 'unofficial_extensions': ('UNTWISTING_ROPE_EXTENSIONS',),
-                'blend_weights': ('ROPE_BLEND_WEIGHTS', {
-                    'tooltip': (
-                        'Optional blend weights from the RoPE Blend Weights node. '
-                        'Controls the relative influence of each reference image when '
-                        'multiple reference images are provided as a batch. '
-                        'If not connected, all references receive equal weight.'
-                    ),
-                }),
             },
         }
 
@@ -1414,12 +1388,9 @@ class UntwistingRoPE:
         low_scale_end: float,
         blocks: str,
         adain_strength: float,
-        block_start: int = 0,
-        block_end: int = 999,
         verbose: bool = False,
         rf_inversion: Optional[Dict[str, Any]] = None,
         unofficial_extensions: Optional[Dict[str, Any]] = None,
-        blend_weights: Optional[List[float]] = None,
     ):
         rf_active, rf_cfg, rf_state, ref_clean_cpu, ref_conditioning, rf_source = _rf_latent_get_config(rf_inversion)
         node_verbose = vp._coerce_bool(verbose)
@@ -1455,7 +1426,7 @@ class UntwistingRoPE:
         vp._vprint(stats, f'{vp._PREFIX} high_scale: {high_scale_start:.3f} → {high_scale_end:.3f}')
         vp._vprint(stats, f'{vp._PREFIX} low_scale:  {low_scale_start:.3f} → {low_scale_end:.3f}')
         vp._vprint(stats,
-            f'{vp._PREFIX} blocks: {blocks if blocks.strip() else f"{block_start}-{block_end}"}  '
+            f'{vp._PREFIX} blocks: {blocks if blocks.strip() else "all"}  '
             f'adain={adain_strength:.2f}  '
             f'unofficial: '
             f'cosine_gated_v_injection={cosine_gated_v_injection:.2f}  '
@@ -1520,27 +1491,7 @@ class UntwistingRoPE:
 
         old_wrapper = model_clone.model_options.get('model_function_wrapper', None)
 
-        # Block range: string overrides ints if non-empty.
-        if blocks.strip():
-            parsed_blocks = _parse_active_blocks(blocks)
-        else:
-            parsed_blocks = set(range(int(block_start), int(block_end) + 1))
-
-        # Multi-reference blend setup.
-        # ref_clean_cpu may be [N, C, H, W] (4D) or [N, C, T, H, W] (5D video).
-        # In either case dim 0 is the batch/reference count.
-        # blend_weights is now a dict {"weights": [...], "mode": "..."} from RoPEBlendWeights.
-        num_ref_streams = int(ref_clean_cpu.shape[0]) if torch.is_tensor(ref_clean_cpu) and ref_clean_cpu.ndim >= 4 else 1
-        if isinstance(blend_weights, dict):
-            blend_weights_raw = blend_weights.get("weights", [])
-            blend_mode = str(blend_weights.get("mode", "round_robin"))
-        elif isinstance(blend_weights, list):
-            blend_weights_raw = blend_weights
-            blend_mode = "round_robin"
-        else:
-            blend_weights_raw = []
-            blend_mode = "round_robin"
-        resolved_blend_weights = resolve_blend_weights(blend_weights_raw, num_ref_streams)
+        parsed_blocks = _parse_active_blocks(blocks)
 
         def model_function_wrapper(apply_model: Callable, args: Dict[str, Any]) -> torch.Tensor:
             stats.wrapper_calls += 1
@@ -1585,9 +1536,6 @@ class UntwistingRoPE:
                 'sigma': sigma,
                 'wrapper_call': call_n,
                 '_rope_scale_debug_printed': False,
-                'num_ref_streams': num_ref_streams,
-                'blend_weights': resolved_blend_weights,
-                'blend_mode': blend_mode,
             }
             default_cfg = getattr(adapter, 'default_runtime_cfg', None)
             if not callable(default_cfg):
@@ -1609,10 +1557,8 @@ class UntwistingRoPE:
 
             if rf_active and torch.is_tensor(ref_clean_cpu):
                 try:
-                    ref_clean_all = ref_clean_cpu.to(device=input_x.device, dtype=input_x.dtype)
-                    # Split batched ref_clean into per-reference slices along dim 0.
-                    # Works for both 4D [N,C,H,W] and 5D [N,C,T,H,W] video latents.
-                    ref_clean_list = [ref_clean_all[i:i+1] for i in range(num_ref_streams)]
+                    ref_clean = ref_clean_cpu.to(device=input_x.device, dtype=input_x.dtype)
+                    ref = _repeat_to_batch(ref_clean, target_b)
 
                     if not rf_state.get('schedule_built', False) and rf_state.get('sampler_sigmas', None) is not None:
                         effective_ref_conditioning, adapter_ref_status = _prepare_reference_conditioning_for_adapter(
@@ -1622,38 +1568,28 @@ class UntwistingRoPE:
                         )
                         rf_kwargs, rf_cond_mode = _build_rf_conditioning_kwargs(c, effective_ref_conditioning, target_b)
                         rf_cond_mode = _append_conditioning_status(rf_cond_mode, adapter_ref_status)
-                                                                                               
+                        rf_ref_clean = _repeat_to_batch(ref_clean, target_b)
                         sampler_sigmas = list(rf_state['sampler_sigmas'])
-
-                        # Build one RF trajectory per reference image.
-                        for ref_i, ref_clean_i in enumerate(ref_clean_list):
-                            rf_ref_clean_i = _repeat_to_batch(ref_clean_i, target_b)
-                            ref_clean_cpu_i = ref_clean_cpu[ref_i:ref_i+1]
-                            built_cache_i, eps_i, sorted_sigmas, cache_key_i, persistent_hit_i = _rf_ensure_trajectory_cache(
-                                rf_inversion=rf_inversion,
-                                rf_state=rf_state,
-                                rf_cfg=rf_cfg,
-                                ref_clean_cpu=ref_clean_cpu_i,
-                                ref_clean_for_build=rf_ref_clean_i,
-                                ref_conditioning=ref_conditioning,
-                                sampler_sigmas=sampler_sigmas,
-                                target_b=target_b,
-                                rf_cond_mode=rf_cond_mode,
-                                apply_model_fn=_make_raw_velocity_apply_model_fn(apply_model),
-                                base_model_kwargs=rf_kwargs,
-                                device=input_x.device,
-                                dtype=input_x.dtype,
-                                stats=stats,
-                                preview_callback_factory=lambda: _rf_make_preview_callback(model_clone, max(1, len(sampler_sigmas) - 1)),
-                                debug_store=debug_store,
-                                parameterization=stats.parameterization,
-                            )
-                            rf_state[f'cache_{ref_i}'] = built_cache_i
-                            if ref_i == 0:
-                                rf_state['cache'] = built_cache_i
-                                rf_state['eps'] = eps_i
-
-                        ref_mode = 'RF sampler-sigma trajectory (persistent-cache hit)' if persistent_hit_i else 'RF sampler-sigma trajectory (built)'
+                        built_cache, eps, sorted_sigmas, cache_key, persistent_hit = _rf_ensure_trajectory_cache(
+                            rf_inversion=rf_inversion,
+                            rf_state=rf_state,
+                            rf_cfg=rf_cfg,
+                            ref_clean_cpu=ref_clean_cpu,
+                            ref_clean_for_build=rf_ref_clean,
+                            ref_conditioning=ref_conditioning,
+                            sampler_sigmas=sampler_sigmas,
+                            target_b=target_b,
+                            rf_cond_mode=rf_cond_mode,
+                            apply_model_fn=_make_raw_velocity_apply_model_fn(apply_model),
+                            base_model_kwargs=rf_kwargs,
+                            device=input_x.device,
+                            dtype=input_x.dtype,
+                            stats=stats,
+                            preview_callback_factory=lambda: _rf_make_preview_callback(model_clone, max(1, len(sampler_sigmas) - 1)),
+                            debug_store=debug_store,
+                            parameterization=stats.parameterization,
+                        )
+                        ref_mode = 'RF sampler-sigma trajectory (persistent-cache hit)' if persistent_hit else 'RF sampler-sigma trajectory (built)'
                         stats.rf_sigma_cache = rf_state['cache']
                         stats.rf_eps = rf_state['eps']
                         stats.rf_schedule_built = True
@@ -1666,7 +1602,6 @@ class UntwistingRoPE:
                             'SAMPLER_SAMPLE must run before UntwistingRoPE model calls.'
                         )
 
-                    # Validate primary cache for backward compat debug.
                     cache = rf_state.get('cache') if isinstance(rf_state.get('cache'), dict) else {}
                     cached, used_sigma_key, cache_lookup = _rf_cache_lookup(cache, sigma_key, allow_nearest=True)
                     if cached is None:
@@ -1679,92 +1614,41 @@ class UntwistingRoPE:
                     debug_store['last_cache_lookup'] = cache_lookup
                     debug_store['last_cache_key'] = float(used_sigma_key)
 
-                                                                                                                                                        
+                    ref_noisy = _repeat_to_batch(cached.to(device=input_x.device, dtype=input_x.dtype), target_b)
 
-                                                                  
-                                                                                                    
-                            
-                                                         
-                                                         
-                                                                                               
-                                                                                           
-                                 
-                                                                                             
-                                                
-                                                                                                                                                     
+                    if ref_noisy.shape[-2:] == input_x.shape[-2:]:
+                        input_for_model = torch.cat([input_x, ref_noisy], dim=0)
+                        try:
+                            if (torch.is_tensor(timestep)
+                                    and timestep.ndim > 0
+                                    and int(timestep.shape[0]) == target_b):
+                                timestep_for_model = torch.cat([timestep, timestep], dim=0)
+                            else:
+                                timestep_for_model = _repeat_to_batch(timestep, target_b * 2)
+                        except Exception as exc:
+                            raise RuntimeError('UntwistingRoPE failed while duplicating timestep for reference batch.') from exc
 
-                    # Build list of noisy latents for all N reference streams.
-                    # Each cache entry may itself be a batch of N items if the
-                    # reference latent was batched; we split along batch dim.
-                    all_ref_noisy = []
-                    for ref_i in range(num_ref_streams):
-                        cache_i = rf_state.get(f'cache_{ref_i}') if num_ref_streams > 1 else rf_state.get('cache')
-                        cache_i = cache_i if isinstance(cache_i, dict) else {}
-                        cached_i, used_sigma_key_i, _ = _rf_cache_lookup(cache_i, sigma_key, allow_nearest=True)
-                        if cached_i is None:
-                            raise RuntimeError(
-                                f'UntwistingRoPE failed: no RF cache entry for ref {ref_i} at sigma={sigma_key:.6f}.'
-                            )
-                        noisy_i = _repeat_to_batch(cached_i.to(device=input_x.device, dtype=input_x.dtype), target_b)
-                        all_ref_noisy.append(noisy_i)
+                        effective_ref_conditioning, adapter_ref_status = _prepare_reference_conditioning_for_adapter(
+                            adapter, ref_conditioning, dm, input_x.device,
+                            c.get('c_crossattn').dtype if torch.is_tensor(c.get('c_crossattn', None)) else input_x.dtype,
+                            stats, label='UntwistingRoPEMerge',
+                        )
+                        c, forced_cap_mask = _merge_reference_conditioning_into_c(c, effective_ref_conditioning, target_b)
+                        cfg['adapter_ref_conditioning_status'] = adapter_ref_status
+                        cfg['forced_cap_mask'] = forced_cap_mask.to(device=input_x.device)
+                        cfg['cross_batch_target_batch'] = target_b
 
-                    # Spatial mismatch check against first reference.
-                    ref_noisy = all_ref_noisy[0]
-                    if ref_noisy.shape[-2:] != input_x.shape[-2:]:
-                                                
-                                                                                                                                               
-                         
+                        try:
+                            if isinstance(cond_or_uncond, list):
+                                cond_or_uncond = cond_or_uncond + cond_or_uncond
+                        except Exception as exc:
+                            raise RuntimeError('UntwistingRoPE failed while duplicating cond_or_uncond metadata.') from exc
+                    else:
                         raise RuntimeError(
                             f'UntwistingRoPE failed: spatial mismatch input_x={tuple(input_x.shape[-2:])} '
                             f'ref_noisy={tuple(ref_noisy.shape[-2:])}. '
-                            f'Make sure the resolution of the reference images matches the output resolution.'
+                            f'Make sure the resolution of the reference image fed into the RF inversion node matches the final image resolution (same width and height).'
                         )
-
-                    # Cat: [target, ref_0, ref_1, ..., ref_{N-1}]
-                    input_for_model = torch.cat([input_x] + all_ref_noisy, dim=0)
-                    try:
-                        total_batch = target_b * (num_ref_streams + 1)
-                        if (torch.is_tensor(timestep)
-                                and timestep.ndim > 0
-                                and int(timestep.shape[0]) == target_b):
-                            timestep_for_model = timestep.repeat(num_ref_streams + 1)
-                        else:
-                            timestep_for_model = _repeat_to_batch(timestep, total_batch)
-                    except Exception as exc:
-                        raise RuntimeError('UntwistingRoPE failed while duplicating timestep for reference batch.') from exc
-
-                    # Merge conditioning for the first reference stream only.
-                    # Additional reference streams share the same conditioning.
-                    effective_ref_conditioning, adapter_ref_status = _prepare_reference_conditioning_for_adapter(
-                        adapter, ref_conditioning, dm, input_x.device,
-                        c.get('c_crossattn').dtype if torch.is_tensor(c.get('c_crossattn', None)) else input_x.dtype,
-                        stats, label='UntwistingRoPEMerge',
-                    )
-                    c, forced_cap_mask = _merge_reference_conditioning_into_c(c, effective_ref_conditioning, target_b)
-                    # Repeat conditioning for all N reference streams.
-                    if num_ref_streams > 1:
-                        for key, val in list(c.items()):
-                            if key == 'transformer_options':
-                                continue
-                            if torch.is_tensor(val) and val.ndim > 0 and int(val.shape[0]) == target_b * 2:
-                                # Already target+ref_0; extend to target+ref_0+...+ref_{N-1}
-                                ref_val = val[target_b:]
-                                c[key] = torch.cat([val] + [ref_val] * (num_ref_streams - 1), dim=0)
-                        forced_cap_mask_extended = torch.cat(
-                            [forced_cap_mask] + [forced_cap_mask[target_b:]] * (num_ref_streams - 1), dim=0
-                        )
-                    else:
-                        forced_cap_mask_extended = forced_cap_mask
-
-                    cfg['adapter_ref_conditioning_status'] = adapter_ref_status
-                    cfg['forced_cap_mask'] = forced_cap_mask_extended.to(device=input_x.device)
-                    cfg['cross_batch_target_batch'] = target_b
-
-                    try:
-                        if isinstance(cond_or_uncond, list):
-                            cond_or_uncond = cond_or_uncond * (num_ref_streams + 1)
-                    except Exception as exc:
-                        raise RuntimeError('UntwistingRoPE failed while duplicating cond_or_uncond metadata.') from exc
                 except RuntimeError:
                     raise
                 except Exception as exc:
@@ -1831,20 +1715,14 @@ from .rf_inversion import (
     _sigma_from_timestep,
     _sigma_to_progress,
 )
-from .blend_weights import RoPEBlendWeights, resolve_blend_weights
-from .multi_ref_encode import MultiRefEncode
 
 NODE_CLASS_MAPPINGS = {
     'RFInversion': RFInversion,
     'UnofficialExtensions': UnofficialExtensions,
     'UntwistingRoPE': UntwistingRoPE,
-    'RoPEBlendWeights': RoPEBlendWeights,
-    'MultiRefEncode': MultiRefEncode,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     'RFInversion': 'RF Inversion',
     'UnofficialExtensions': 'Unofficial Extensions',
     'UntwistingRoPE': 'Untwisting RoPE',
-    'RoPEBlendWeights': 'RoPE Blend Weights',
-    'MultiRefEncode': 'Multi-Ref Encode',
 }

--- a/__init__.py
+++ b/__init__.py
@@ -1364,9 +1364,27 @@ class UntwistingRoPE:
                     'step': 0.01,
                     'tooltip': 'AdaIN aligns the target style statistics toward the reference.'
                 }),
+                'block_start': ('INT', {
+                    'default': 0,
+                    'min': 0,
+                    'max': 999,
+                    'step': 1,
+                    'tooltip': 'First block to patch (inclusive). Used when blocks string is empty.',
+                }),
+                'block_end': ('INT', {
+                    'default': 999,
+                    'min': 0,
+                    'max': 999,
+                    'step': 1,
+                    'tooltip': 'Last block to patch (inclusive). Used when blocks string is empty.',
+                }),
                 'blocks': ('STRING', {
-                    'default': '0-999',
-                    'tooltip': 'Specify block ranges to patch, e.g -> 0-8, 28-37'
+                    'default': '',
+                    'tooltip': (
+                        'Optional block range override, e.g. "7-27" or "0-8, 20-27". '
+                        'If non-empty, overrides block_start and block_end. '
+                        'If empty, block_start and block_end are used.'
+                    ),
                 }),
                 'verbose': ('BOOLEAN', {
                     'default': False,
@@ -1375,6 +1393,14 @@ class UntwistingRoPE:
             },
             'optional': {
                 'unofficial_extensions': ('UNTWISTING_ROPE_EXTENSIONS',),
+                'blend_weights': ('ROPE_BLEND_WEIGHTS', {
+                    'tooltip': (
+                        'Optional blend weights from the RoPE Blend Weights node. '
+                        'Controls the relative influence of each reference image when '
+                        'multiple reference images are provided as a batch. '
+                        'If not connected, all references receive equal weight.'
+                    ),
+                }),
             },
         }
 
@@ -1388,9 +1414,12 @@ class UntwistingRoPE:
         low_scale_end: float,
         blocks: str,
         adain_strength: float,
+        block_start: int = 0,
+        block_end: int = 999,
         verbose: bool = False,
         rf_inversion: Optional[Dict[str, Any]] = None,
         unofficial_extensions: Optional[Dict[str, Any]] = None,
+        blend_weights: Optional[List[float]] = None,
     ):
         rf_active, rf_cfg, rf_state, ref_clean_cpu, ref_conditioning, rf_source = _rf_latent_get_config(rf_inversion)
         node_verbose = vp._coerce_bool(verbose)
@@ -1426,7 +1455,7 @@ class UntwistingRoPE:
         vp._vprint(stats, f'{vp._PREFIX} high_scale: {high_scale_start:.3f} → {high_scale_end:.3f}')
         vp._vprint(stats, f'{vp._PREFIX} low_scale:  {low_scale_start:.3f} → {low_scale_end:.3f}')
         vp._vprint(stats,
-            f'{vp._PREFIX} blocks: {blocks if blocks.strip() else "all"}  '
+            f'{vp._PREFIX} blocks: {blocks if blocks.strip() else f"{block_start}-{block_end}"}  '
             f'adain={adain_strength:.2f}  '
             f'unofficial: '
             f'cosine_gated_v_injection={cosine_gated_v_injection:.2f}  '
@@ -1491,7 +1520,27 @@ class UntwistingRoPE:
 
         old_wrapper = model_clone.model_options.get('model_function_wrapper', None)
 
-        parsed_blocks = _parse_active_blocks(blocks)
+        # Block range: string overrides ints if non-empty.
+        if blocks.strip():
+            parsed_blocks = _parse_active_blocks(blocks)
+        else:
+            parsed_blocks = set(range(int(block_start), int(block_end) + 1))
+
+        # Multi-reference blend setup.
+        # ref_clean_cpu may be [N, C, H, W] (4D) or [N, C, T, H, W] (5D video).
+        # In either case dim 0 is the batch/reference count.
+        # blend_weights is now a dict {"weights": [...], "mode": "..."} from RoPEBlendWeights.
+        num_ref_streams = int(ref_clean_cpu.shape[0]) if torch.is_tensor(ref_clean_cpu) and ref_clean_cpu.ndim >= 4 else 1
+        if isinstance(blend_weights, dict):
+            blend_weights_raw = blend_weights.get("weights", [])
+            blend_mode = str(blend_weights.get("mode", "round_robin"))
+        elif isinstance(blend_weights, list):
+            blend_weights_raw = blend_weights
+            blend_mode = "round_robin"
+        else:
+            blend_weights_raw = []
+            blend_mode = "round_robin"
+        resolved_blend_weights = resolve_blend_weights(blend_weights_raw, num_ref_streams)
 
         def model_function_wrapper(apply_model: Callable, args: Dict[str, Any]) -> torch.Tensor:
             stats.wrapper_calls += 1
@@ -1536,6 +1585,9 @@ class UntwistingRoPE:
                 'sigma': sigma,
                 'wrapper_call': call_n,
                 '_rope_scale_debug_printed': False,
+                'num_ref_streams': num_ref_streams,
+                'blend_weights': resolved_blend_weights,
+                'blend_mode': blend_mode,
             }
             default_cfg = getattr(adapter, 'default_runtime_cfg', None)
             if not callable(default_cfg):
@@ -1557,8 +1609,10 @@ class UntwistingRoPE:
 
             if rf_active and torch.is_tensor(ref_clean_cpu):
                 try:
-                    ref_clean = ref_clean_cpu.to(device=input_x.device, dtype=input_x.dtype)
-                    ref = _repeat_to_batch(ref_clean, target_b)
+                    ref_clean_all = ref_clean_cpu.to(device=input_x.device, dtype=input_x.dtype)
+                    # Split batched ref_clean into per-reference slices along dim 0.
+                    # Works for both 4D [N,C,H,W] and 5D [N,C,T,H,W] video latents.
+                    ref_clean_list = [ref_clean_all[i:i+1] for i in range(num_ref_streams)]
 
                     if not rf_state.get('schedule_built', False) and rf_state.get('sampler_sigmas', None) is not None:
                         effective_ref_conditioning, adapter_ref_status = _prepare_reference_conditioning_for_adapter(
@@ -1568,28 +1622,38 @@ class UntwistingRoPE:
                         )
                         rf_kwargs, rf_cond_mode = _build_rf_conditioning_kwargs(c, effective_ref_conditioning, target_b)
                         rf_cond_mode = _append_conditioning_status(rf_cond_mode, adapter_ref_status)
-                        rf_ref_clean = _repeat_to_batch(ref_clean, target_b)
+                                                                                               
                         sampler_sigmas = list(rf_state['sampler_sigmas'])
-                        built_cache, eps, sorted_sigmas, cache_key, persistent_hit = _rf_ensure_trajectory_cache(
-                            rf_inversion=rf_inversion,
-                            rf_state=rf_state,
-                            rf_cfg=rf_cfg,
-                            ref_clean_cpu=ref_clean_cpu,
-                            ref_clean_for_build=rf_ref_clean,
-                            ref_conditioning=ref_conditioning,
-                            sampler_sigmas=sampler_sigmas,
-                            target_b=target_b,
-                            rf_cond_mode=rf_cond_mode,
-                            apply_model_fn=_make_raw_velocity_apply_model_fn(apply_model),
-                            base_model_kwargs=rf_kwargs,
-                            device=input_x.device,
-                            dtype=input_x.dtype,
-                            stats=stats,
-                            preview_callback_factory=lambda: _rf_make_preview_callback(model_clone, max(1, len(sampler_sigmas) - 1)),
-                            debug_store=debug_store,
-                            parameterization=stats.parameterization,
-                        )
-                        ref_mode = 'RF sampler-sigma trajectory (persistent-cache hit)' if persistent_hit else 'RF sampler-sigma trajectory (built)'
+
+                        # Build one RF trajectory per reference image.
+                        for ref_i, ref_clean_i in enumerate(ref_clean_list):
+                            rf_ref_clean_i = _repeat_to_batch(ref_clean_i, target_b)
+                            ref_clean_cpu_i = ref_clean_cpu[ref_i:ref_i+1]
+                            built_cache_i, eps_i, sorted_sigmas, cache_key_i, persistent_hit_i = _rf_ensure_trajectory_cache(
+                                rf_inversion=rf_inversion,
+                                rf_state=rf_state,
+                                rf_cfg=rf_cfg,
+                                ref_clean_cpu=ref_clean_cpu_i,
+                                ref_clean_for_build=rf_ref_clean_i,
+                                ref_conditioning=ref_conditioning,
+                                sampler_sigmas=sampler_sigmas,
+                                target_b=target_b,
+                                rf_cond_mode=rf_cond_mode,
+                                apply_model_fn=_make_raw_velocity_apply_model_fn(apply_model),
+                                base_model_kwargs=rf_kwargs,
+                                device=input_x.device,
+                                dtype=input_x.dtype,
+                                stats=stats,
+                                preview_callback_factory=lambda: _rf_make_preview_callback(model_clone, max(1, len(sampler_sigmas) - 1)),
+                                debug_store=debug_store,
+                                parameterization=stats.parameterization,
+                            )
+                            rf_state[f'cache_{ref_i}'] = built_cache_i
+                            if ref_i == 0:
+                                rf_state['cache'] = built_cache_i
+                                rf_state['eps'] = eps_i
+
+                        ref_mode = 'RF sampler-sigma trajectory (persistent-cache hit)' if persistent_hit_i else 'RF sampler-sigma trajectory (built)'
                         stats.rf_sigma_cache = rf_state['cache']
                         stats.rf_eps = rf_state['eps']
                         stats.rf_schedule_built = True
@@ -1602,6 +1666,7 @@ class UntwistingRoPE:
                             'SAMPLER_SAMPLE must run before UntwistingRoPE model calls.'
                         )
 
+                    # Validate primary cache for backward compat debug.
                     cache = rf_state.get('cache') if isinstance(rf_state.get('cache'), dict) else {}
                     cached, used_sigma_key, cache_lookup = _rf_cache_lookup(cache, sigma_key, allow_nearest=True)
                     if cached is None:
@@ -1614,41 +1679,92 @@ class UntwistingRoPE:
                     debug_store['last_cache_lookup'] = cache_lookup
                     debug_store['last_cache_key'] = float(used_sigma_key)
 
-                    ref_noisy = _repeat_to_batch(cached.to(device=input_x.device, dtype=input_x.dtype), target_b)
+                                                                                                                                                        
 
-                    if ref_noisy.shape[-2:] == input_x.shape[-2:]:
-                        input_for_model = torch.cat([input_x, ref_noisy], dim=0)
-                        try:
-                            if (torch.is_tensor(timestep)
-                                    and timestep.ndim > 0
-                                    and int(timestep.shape[0]) == target_b):
-                                timestep_for_model = torch.cat([timestep, timestep], dim=0)
-                            else:
-                                timestep_for_model = _repeat_to_batch(timestep, target_b * 2)
-                        except Exception as exc:
-                            raise RuntimeError('UntwistingRoPE failed while duplicating timestep for reference batch.') from exc
+                                                                  
+                                                                                                    
+                            
+                                                         
+                                                         
+                                                                                               
+                                                                                           
+                                 
+                                                                                             
+                                                
+                                                                                                                                                     
 
-                        effective_ref_conditioning, adapter_ref_status = _prepare_reference_conditioning_for_adapter(
-                            adapter, ref_conditioning, dm, input_x.device,
-                            c.get('c_crossattn').dtype if torch.is_tensor(c.get('c_crossattn', None)) else input_x.dtype,
-                            stats, label='UntwistingRoPEMerge',
-                        )
-                        c, forced_cap_mask = _merge_reference_conditioning_into_c(c, effective_ref_conditioning, target_b)
-                        cfg['adapter_ref_conditioning_status'] = adapter_ref_status
-                        cfg['forced_cap_mask'] = forced_cap_mask.to(device=input_x.device)
-                        cfg['cross_batch_target_batch'] = target_b
+                    # Build list of noisy latents for all N reference streams.
+                    # Each cache entry may itself be a batch of N items if the
+                    # reference latent was batched; we split along batch dim.
+                    all_ref_noisy = []
+                    for ref_i in range(num_ref_streams):
+                        cache_i = rf_state.get(f'cache_{ref_i}') if num_ref_streams > 1 else rf_state.get('cache')
+                        cache_i = cache_i if isinstance(cache_i, dict) else {}
+                        cached_i, used_sigma_key_i, _ = _rf_cache_lookup(cache_i, sigma_key, allow_nearest=True)
+                        if cached_i is None:
+                            raise RuntimeError(
+                                f'UntwistingRoPE failed: no RF cache entry for ref {ref_i} at sigma={sigma_key:.6f}.'
+                            )
+                        noisy_i = _repeat_to_batch(cached_i.to(device=input_x.device, dtype=input_x.dtype), target_b)
+                        all_ref_noisy.append(noisy_i)
 
-                        try:
-                            if isinstance(cond_or_uncond, list):
-                                cond_or_uncond = cond_or_uncond + cond_or_uncond
-                        except Exception as exc:
-                            raise RuntimeError('UntwistingRoPE failed while duplicating cond_or_uncond metadata.') from exc
-                    else:
+                    # Spatial mismatch check against first reference.
+                    ref_noisy = all_ref_noisy[0]
+                    if ref_noisy.shape[-2:] != input_x.shape[-2:]:
+                                                
+                                                                                                                                               
+                         
                         raise RuntimeError(
                             f'UntwistingRoPE failed: spatial mismatch input_x={tuple(input_x.shape[-2:])} '
                             f'ref_noisy={tuple(ref_noisy.shape[-2:])}. '
-                            f'Make sure the resolution of the reference image fed into the RF inversion node matches the final image resolution (same width and height).'
+                            f'Make sure the resolution of the reference images matches the output resolution.'
                         )
+
+                    # Cat: [target, ref_0, ref_1, ..., ref_{N-1}]
+                    input_for_model = torch.cat([input_x] + all_ref_noisy, dim=0)
+                    try:
+                        total_batch = target_b * (num_ref_streams + 1)
+                        if (torch.is_tensor(timestep)
+                                and timestep.ndim > 0
+                                and int(timestep.shape[0]) == target_b):
+                            timestep_for_model = timestep.repeat(num_ref_streams + 1)
+                        else:
+                            timestep_for_model = _repeat_to_batch(timestep, total_batch)
+                    except Exception as exc:
+                        raise RuntimeError('UntwistingRoPE failed while duplicating timestep for reference batch.') from exc
+
+                    # Merge conditioning for the first reference stream only.
+                    # Additional reference streams share the same conditioning.
+                    effective_ref_conditioning, adapter_ref_status = _prepare_reference_conditioning_for_adapter(
+                        adapter, ref_conditioning, dm, input_x.device,
+                        c.get('c_crossattn').dtype if torch.is_tensor(c.get('c_crossattn', None)) else input_x.dtype,
+                        stats, label='UntwistingRoPEMerge',
+                    )
+                    c, forced_cap_mask = _merge_reference_conditioning_into_c(c, effective_ref_conditioning, target_b)
+                    # Repeat conditioning for all N reference streams.
+                    if num_ref_streams > 1:
+                        for key, val in list(c.items()):
+                            if key == 'transformer_options':
+                                continue
+                            if torch.is_tensor(val) and val.ndim > 0 and int(val.shape[0]) == target_b * 2:
+                                # Already target+ref_0; extend to target+ref_0+...+ref_{N-1}
+                                ref_val = val[target_b:]
+                                c[key] = torch.cat([val] + [ref_val] * (num_ref_streams - 1), dim=0)
+                        forced_cap_mask_extended = torch.cat(
+                            [forced_cap_mask] + [forced_cap_mask[target_b:]] * (num_ref_streams - 1), dim=0
+                        )
+                    else:
+                        forced_cap_mask_extended = forced_cap_mask
+
+                    cfg['adapter_ref_conditioning_status'] = adapter_ref_status
+                    cfg['forced_cap_mask'] = forced_cap_mask_extended.to(device=input_x.device)
+                    cfg['cross_batch_target_batch'] = target_b
+
+                    try:
+                        if isinstance(cond_or_uncond, list):
+                            cond_or_uncond = cond_or_uncond * (num_ref_streams + 1)
+                    except Exception as exc:
+                        raise RuntimeError('UntwistingRoPE failed while duplicating cond_or_uncond metadata.') from exc
                 except RuntimeError:
                     raise
                 except Exception as exc:
@@ -1715,14 +1831,20 @@ from .rf_inversion import (
     _sigma_from_timestep,
     _sigma_to_progress,
 )
+from .blend_weights import RoPEBlendWeights, resolve_blend_weights
+from .multi_ref_encode import MultiRefEncode
 
 NODE_CLASS_MAPPINGS = {
     'RFInversion': RFInversion,
     'UnofficialExtensions': UnofficialExtensions,
     'UntwistingRoPE': UntwistingRoPE,
+    'RoPEBlendWeights': RoPEBlendWeights,
+    'MultiRefEncode': MultiRefEncode,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     'RFInversion': 'RF Inversion',
     'UnofficialExtensions': 'Unofficial Extensions',
     'UntwistingRoPE': 'Untwisting RoPE',
+    'RoPEBlendWeights': 'RoPE Blend Weights',
+    'MultiRefEncode': 'Multi-Ref Encode',
 }

--- a/models/krea2.py
+++ b/models/krea2.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+"""Krea 2 adapter for ComfyUi-Untwisting-RoPE.
+
+Single-stream MMDiT: fused text+image tokens processed by blocks.N.attn.
+Style transfer mirrors other adapters: target Q attends to target K/V plus
+scaled reference-image K/V; shared QKV and attention-output effects are
+delegated to the top-level UntwistingRoPE helpers.
+
+imglen injection: dm.txtmlp.forward is patched to store txtlen on dm after
+the text fusion step. The block-level patch reads this and injects
+krea2_imglen = seqlen - txtlen into transformer_options before self.attn
+is called. This is reliable because txtmlp is a plain nn.Module whose
+forward survives VRAM reloads, unlike dm._forward which is bypassed by
+WrapperExecutor.
+"""
+
+import math
+import types
+from typing import Any, List, Optional
+
+import torch
+from einops import rearrange
+from comfy.ldm.flux.math import apply_rope
+from comfy.ldm.modules.attention import optimized_attention_masked
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity
+# ---------------------------------------------------------------------------
+
+ARCHITECTURE = "krea2"
+DISPLAY_NAME = "Krea 2"
+CONFIG_KEY = "untwisting_rope"
+
+SUPPORTED_MODEL_CONFIG_CLASSES: set[str] = {"Krea2"}
+
+DIFFUSION_ATTR_PATHS = (
+    "model.diffusion_model",
+    "model.model.diffusion_model",
+    "inner_model.diffusion_model",
+    "model.inner_model.diffusion_model",
+    "diffusion_model",
+)
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers
+# ---------------------------------------------------------------------------
+
+def _get_attr_path(root: Any, attr_path: str) -> tuple[Any, bool]:
+    obj = root
+    for part in attr_path.split("."):
+        if obj is None or not hasattr(obj, part):
+            return None, False
+        try:
+            obj = getattr(obj, part)
+        except Exception:
+            return None, False
+    return obj, True
+
+
+def _safe_int(value: Any, default: Optional[int] = None) -> Optional[int]:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _lerp(a: float, b: float, t: float) -> float:
+    return float(a + (b - a) * t)
+
+
+# ---------------------------------------------------------------------------
+# Required adapter hooks
+# ---------------------------------------------------------------------------
+
+def matches_model(model_info: dict[str, Any]) -> bool:
+    return str(model_info.get("model_config_class", "")) in SUPPORTED_MODEL_CONFIG_CLASSES
+
+
+def is_model_identity(model_info: dict[str, Any]) -> bool:
+    return matches_model(model_info)
+
+
+def find_diffusion_model(model_patcher: Any) -> Any:
+    for path in DIFFUSION_ATTR_PATHS:
+        obj, ok = _get_attr_path(model_patcher, path)
+        if ok and obj is not None:
+            return obj
+    raise RuntimeError(f"Could not find ComfyUI BaseModel.diffusion_model for {DISPLAY_NAME}.")
+
+
+# ---------------------------------------------------------------------------
+# Krea 2 metadata
+# ---------------------------------------------------------------------------
+
+def axes_dims_from_head_dim(head_dim: int) -> List[int]:
+    """Exact 3-axis split from comfy/ldm/krea2/model.py SingleStreamDiT."""
+    hd = int(head_dim)
+    axes = [hd - 12 * (hd // 16), 6 * (hd // 16), 6 * (hd // 16)]
+    if sum(axes) != hd or any(v <= 0 for v in axes):
+        raise RuntimeError(
+            f"{DISPLAY_NAME} axes_dims: cannot split head_dim={hd} into [T,H,W]: {axes}."
+        )
+    return axes
+
+
+def _first_main_attention(dm: Any) -> Any:
+    blocks = getattr(dm, "blocks", None)
+    if blocks is None:
+        raise RuntimeError(f"{DISPLAY_NAME} metadata lookup failed: dm.blocks is missing.")
+    try:
+        block0 = blocks[0]
+    except Exception as exc:
+        raise RuntimeError(f"{DISPLAY_NAME} dm.blocks[0] unavailable.") from exc
+    attn = getattr(block0, "attn", None)
+    if attn is None:
+        raise RuntimeError(f"{DISPLAY_NAME} dm.blocks[0].attn is missing.")
+    return attn
+
+
+def head_dim_from_dm(dm: Any | None) -> int:
+    if dm is None:
+        return 128  # Krea2 default: features=6144, heads=48
+    attn = _first_main_attention(dm)
+    head_dim = _safe_int(getattr(attn, "headdim", None))
+    if head_dim is None or head_dim <= 0:
+        raise RuntimeError(f"{DISPLAY_NAME} invalid headdim={head_dim!r}.")
+    return int(head_dim)
+
+
+def default_runtime_cfg(dm: Any | None = None) -> dict[str, Any]:
+    head_dim = head_dim_from_dm(dm)
+    return {
+        "architecture": ARCHITECTURE,
+        "head_dim": head_dim,
+        "axes_dims": axes_dims_from_head_dim(head_dim),
+        "target_qk_adain_ranges": [(0, 2**31 - 1)],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Patch target predicates
+# ---------------------------------------------------------------------------
+
+def _index_in_range(parts: list[str], min_layer: int, max_layer: int) -> bool:
+    if len(parts) < 2:
+        return False
+    idx = _safe_int(parts[1])
+    if idx is None:
+        return False
+    return int(min_layer) <= idx <= int(max_layer)
+
+
+def is_main_block_name(name: str, min_layer: int = 0, max_layer: int = 999) -> bool:
+    parts = str(name).split(".")
+    return len(parts) == 2 and parts[0] == "blocks" and _index_in_range(parts, min_layer, max_layer)
+
+
+def is_main_block_attention_name(name: str, min_layer: int = 0, max_layer: int = 999) -> bool:
+    parts = str(name).split(".")
+    return (
+        len(parts) == 3
+        and parts[0] == "blocks"
+        and parts[2] == "attn"
+        and _index_in_range(parts, min_layer, max_layer)
+    )
+
+
+def is_attention_name(name: str, min_layer: int = 0, max_layer: int = 999) -> bool:
+    return is_main_block_attention_name(name, min_layer, max_layer)
+
+
+def block_index_from_name(name: str) -> int:
+    parts = str(name).split(".")
+    if len(parts) >= 2 and parts[0] == "blocks":
+        idx = _safe_int(parts[1], -1)
+        return -1 if idx is None else int(idx)
+    return -1
+
+
+def is_krea2_attention_module(module: Any) -> bool:
+    required = ("wq", "wk", "wv", "wo", "gate", "qknorm", "heads", "kvheads", "headdim", "forward")
+    return all(hasattr(module, attr) for attr in required) and callable(getattr(module, "forward", None))
+
+
+def is_krea2_single_stream_block(module: Any) -> bool:
+    required = ("mod", "prenorm", "postnorm", "attn", "mlp", "forward")
+    return all(hasattr(module, attr) for attr in required) and callable(getattr(module, "forward", None))
+
+
+def is_joint_attention(module: Any) -> bool:
+    return is_krea2_attention_module(module)
+
+
+def prepare_reference_conditioning(
+    ref_conditioning: Any,
+    dm: Any,
+    device: Any,
+    dtype: Any,
+    stats: Any = None,
+    label: str = "",
+    helpers: dict[str, Any] | None = None,
+) -> tuple[Any, str]:
+    return ref_conditioning, "not-applicable"
+
+
+# ---------------------------------------------------------------------------
+# Runtime helpers
+# ---------------------------------------------------------------------------
+
+def _expand_kv_heads(
+    k: torch.Tensor, v: torch.Tensor, q_heads: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    kv_heads = int(k.shape[1])
+    q_heads = int(q_heads)
+    if kv_heads == q_heads:
+        return k, v
+    if kv_heads <= 0 or q_heads % kv_heads != 0:
+        raise RuntimeError(
+            f"{DISPLAY_NAME} cannot expand KV heads: q_heads={q_heads}, kv_heads={kv_heads}."
+        )
+    rep = q_heads // kv_heads
+    return k.repeat_interleave(rep, dim=1), v.repeat_interleave(rep, dim=1)
+
+
+def _image_range(transformer_options: Any, dm: Any, seqlen: int) -> tuple[int, int]:
+    """Resolve image token range from transformer_options or dm fallback."""
+    imglen = None
+    if isinstance(transformer_options, dict):
+        imglen = transformer_options.get("krea2_imglen", None)
+    if imglen is None:
+        imglen = getattr(dm, "_untwist_krea2_last_imglen", None)
+    if imglen is None:
+        raise RuntimeError(
+            f"{DISPLAY_NAME} could not determine image token length. "
+            "txtmlp hook did not populate dm._untwist_krea2_last_txtlen."
+        )
+    imglen_i = max(0, min(int(imglen), int(seqlen)))
+    img_s = int(seqlen) - imglen_i
+    img_e = int(seqlen)
+    if img_e <= img_s:
+        raise RuntimeError(
+            f"{DISPLAY_NAME} empty image token range: imglen={imglen_i}, seqlen={seqlen}."
+        )
+    return img_s, img_e
+
+
+# ---------------------------------------------------------------------------
+# Main patch
+# ---------------------------------------------------------------------------
+
+def patch_attention_modules(
+    dm: Any,
+    stats: Any,
+    helpers: dict[str, Any] | None = None,
+) -> tuple[int, int, int, list[str]]:
+    helpers = helpers or {}
+    prefix = str(helpers.get("prefix", "[UntwistingRoPE]"))
+    config_key = str(helpers.get("config_key", CONFIG_KEY))
+
+    required_helpers = (
+        "patch_context_refiner_mask_modules",
+        "build_frequency_scale_vector",
+        "apply_qkv_shared_effects",
+        "apply_attention_output_shared_effects",
+    )
+    missing = [n for n in required_helpers if not callable(helpers.get(n))]
+    if missing:
+        raise RuntimeError(f"{DISPLAY_NAME} adapter missing required helper(s): {missing}")
+
+    build_frequency_scale_vector = helpers["build_frequency_scale_vector"]
+    apply_qkv_shared_effects = helpers["apply_qkv_shared_effects"]
+    apply_attention_output_shared_effects = helpers["apply_attention_output_shared_effects"]
+
+    helpers["patch_context_refiner_mask_modules"](dm, stats)
+
+    # ------------------------------------------------------------------
+    # imglen injection strategy
+    # ------------------------------------------------------------------
+    # dm._forward is bypassed by WrapperExecutor so we cannot rely on it.
+    # Instead we patch two plain nn.Module submodules whose forwards DO
+    # survive VRAM reloads:
+    #
+    # 1. dm.txtmlp.forward: runs right before combined = cat(context, img)
+    #    in _forward. Its input x has shape [B, txtlen, features].
+    #    We store txtlen on dm.
+    #
+    # 2. dm.blocks[N].forward (SingleStreamBlock): runs in the block loop
+    #    with x = combined [B, seqlen, C]. We compute imglen = seqlen -
+    #    txtlen and inject krea2_imglen into transformer_options before
+    #    self.attn is called.
+    # ------------------------------------------------------------------
+
+    # Patch txtmlp to store txtlen.
+    txtmlp = getattr(dm, "txtmlp", None)
+    if txtmlp is not None and not hasattr(txtmlp, "_untwist_orig_krea2_txtmlp_forward"):
+        txtmlp._untwist_orig_krea2_txtmlp_forward = txtmlp.forward
+        orig_txtmlp_fwd = txtmlp._untwist_orig_krea2_txtmlp_forward
+
+        def patched_txtmlp_forward(self, x):
+            dm._untwist_krea2_last_txtlen = (
+                int(x.shape[1]) if torch.is_tensor(x) and x.ndim >= 2 else None
+            )
+            return orig_txtmlp_fwd(x)
+
+        txtmlp.forward = types.MethodType(patched_txtmlp_forward, txtmlp)
+
+    # Patch SingleStreamBlock.forward to inject krea2_imglen.
+    for name, module in dm.named_modules():
+        if not is_main_block_name(name, 0, 999):
+            continue
+        if not is_krea2_single_stream_block(module):
+            continue
+        if hasattr(module, "_untwist_orig_krea2_block_forward"):
+            continue
+
+        module._untwist_orig_krea2_block_forward = module.forward
+        orig_block_fwd = module._untwist_orig_krea2_block_forward
+
+        def make_block_forward(orig):
+            def patched_block_forward(self, x, vec, freqs, mask=None, transformer_options={}):
+                if isinstance(transformer_options, dict) and "krea2_imglen" not in transformer_options:
+                    cfg = transformer_options.get(config_key)
+                    if cfg and cfg.get("enabled"):
+                        txtlen = getattr(dm, "_untwist_krea2_last_txtlen", None)
+                        if txtlen is not None and torch.is_tensor(x) and x.ndim >= 2:
+                            imglen = x.shape[1] - txtlen
+                            if imglen > 0:
+                                transformer_options = transformer_options.copy()
+                                transformer_options["krea2_imglen"] = imglen
+                return orig(x, vec, freqs, mask=mask, transformer_options=transformer_options)
+            return patched_block_forward
+
+        module.forward = types.MethodType(make_block_forward(orig_block_fwd), module)
+
+    # ------------------------------------------------------------------
+    # Attention patch
+    # ------------------------------------------------------------------
+    matched = installed = restored = 0
+    patched_names: list[str] = []
+
+    for name, module in dm.named_modules():
+        if not is_attention_name(name, 0, 999):
+            continue
+        if not is_krea2_attention_module(module):
+            continue
+
+        matched += 1
+        patched_names.append(name)
+
+        if hasattr(module, "_untwist_orig_krea2_attention_forward"):
+            module.forward = module._untwist_orig_krea2_attention_forward
+            restored += 1
+        else:
+            module._untwist_orig_krea2_attention_forward = module.forward
+
+        original_forward = module._untwist_orig_krea2_attention_forward
+
+        def make_forward(orig, module_name: str):
+            def patched_forward(self, x, freqs=None, mask=None, transformer_options={}):
+                try:
+                    cfg = (
+                        transformer_options.get(config_key)
+                        if isinstance(transformer_options, dict) else None
+                    )
+                    if not cfg or not cfg.get("enabled"):
+                        return orig(x, freqs=freqs, mask=mask,
+                                    transformer_options=transformer_options)
+
+                    target_bsz = int(cfg.get("cross_batch_target_batch", 0))
+                    if target_bsz <= 0:
+                        raise RuntimeError(
+                            f"{DISPLAY_NAME} enabled in {module_name} but "
+                            f"cross_batch_target_batch={target_bsz}."
+                        )
+                    if not torch.is_tensor(x) or x.ndim != 3:
+                        raise RuntimeError(
+                            f"{DISPLAY_NAME} expected x as [B,S,C] in {module_name}; "
+                            f"got {type(x).__name__} ndim={getattr(x, 'ndim', None)}."
+                        )
+
+                    bsz, seqlen, _ = x.shape
+                    if bsz < target_bsz * 2:
+                        raise RuntimeError(
+                            f"{DISPLAY_NAME} expected target+reference batches in "
+                            f"{module_name}; bsz={bsz}, target_bsz={target_bsz}."
+                        )
+
+                    block_idx = int(transformer_options.get(
+                        "block_index", block_index_from_name(module_name)
+                    ))
+                    active_blocks = cfg.get("active_blocks", set())
+                    if active_blocks and block_idx not in active_blocks:
+                        return orig(x, freqs=freqs, mask=mask,
+                                    transformer_options=transformer_options)
+
+                    img_s, img_e = _image_range(transformer_options, dm, seqlen)
+                    token_ranges = [(img_s, img_e)]
+
+                    if hasattr(stats, "attn_calls"):
+                        stats.attn_calls += 1
+
+                    q_heads = int(getattr(self, "heads", 0))
+                    kv_heads = int(getattr(self, "kvheads", q_heads))
+                    head_dim = int(getattr(self, "headdim", 0))
+                    if q_heads <= 0 or kv_heads <= 0 or head_dim <= 0:
+                        raise RuntimeError(
+                            f"{DISPLAY_NAME} invalid attention metadata in {module_name}: "
+                            f"heads={q_heads}, kvheads={kv_heads}, headdim={head_dim}."
+                        )
+
+                    # Q/K/V projections — BHSD layout throughout.
+                    q = rearrange(self.wq(x), "B L (H D) -> B H L D", H=q_heads)
+                    k = rearrange(self.wk(x), "B L (H D) -> B H L D", H=kv_heads)
+                    v = rearrange(self.wv(x), "B L (H D) -> B H L D", H=kv_heads)
+                    gate = self.gate(x)
+
+                    q, k = self.qknorm(q, k)
+                    if freqs is not None:
+                        q, k = apply_rope(q, k, freqs)
+
+                    # GQA expand before shared effects so helpers see full heads.
+                    k, v = _expand_kv_heads(k, v, q_heads)
+
+                    # Shared AdaIN/cosine effects on image tokens, BHSD layout.
+                    q, k, v = apply_qkv_shared_effects(
+                        q, k, v,
+                        cfg,
+                        target_bsz,
+                        module_name,
+                        layout="BHSD",
+                        token_ranges=token_ranges,
+                    )
+
+                    # Frequency scale vector for reference K modulation.
+                    progress = float(cfg.get("progress", 0.0))
+                    high_scale = _lerp(
+                        float(cfg["high_scale_start"]), float(cfg["high_scale_end"]), progress
+                    )
+                    low_scale = _lerp(
+                        float(cfg["low_scale_start"]), float(cfg["low_scale_end"]), progress
+                    )
+                    beta = float(cfg.get("beta", 2.0))
+                    axes_dims = cfg.get("axes_dims") or axes_dims_from_head_dim(head_dim)
+                    scale_vec = build_frequency_scale_vector(
+                        head_dim, axes_dims, high_scale, low_scale, beta,
+                        k.device, k.dtype, runtime_cfg=cfg,
+                    ).view(1, 1, 1, head_dim)
+
+                    # Target attends to its own K/V plus scaled reference image K/V.
+                    # V is left unscaled — only K frequency content is modulated.
+                    ref_k_img = k[target_bsz:target_bsz * 2, :, img_s:img_e, :] * scale_vec
+                    ref_v_img = v[target_bsz:target_bsz * 2, :, img_s:img_e, :]
+
+                    k_t = torch.cat([k[:target_bsz], ref_k_img], dim=2)
+                    v_t = torch.cat([v[:target_bsz], ref_v_img], dim=2)
+
+                    # If a mask is supplied (unexpected but guard for future compat),
+                    # fall back to native attention to avoid shape mismatch.
+                    if mask is not None:
+                        return orig(x, freqs=freqs, mask=mask,
+                                    transformer_options=transformer_options)
+
+                    out_t = optimized_attention_masked(
+                        q[:target_bsz], k_t, v_t, q_heads,
+                        mask=None, skip_reshape=True,
+                        transformer_options=transformer_options,
+                    )
+                    out_r = optimized_attention_masked(
+                        q[target_bsz:target_bsz * 2],
+                        k[target_bsz:target_bsz * 2],
+                        v[target_bsz:target_bsz * 2],
+                        q_heads, mask=None, skip_reshape=True,
+                        transformer_options=transformer_options,
+                    )
+
+                    out_t, out_r = apply_attention_output_shared_effects(
+                        out_t, out_r, cfg, target_bsz, module_name,
+                        layout="BSD", token_ranges=token_ranges,
+                    )
+
+                    outs = [out_t, out_r]
+                    if bsz > target_bsz * 2:
+                        out_extra = optimized_attention_masked(
+                            q[target_bsz * 2:],
+                            k[target_bsz * 2:],
+                            v[target_bsz * 2:],
+                            q_heads, mask=None, skip_reshape=True,
+                            transformer_options=transformer_options,
+                        )
+                        outs.append(out_extra)
+
+                    out = torch.cat(outs, dim=0)
+                    if out.shape != gate.shape:
+                        raise RuntimeError(
+                            f"{DISPLAY_NAME} output/gate shape mismatch in {module_name}: "
+                            f"out={tuple(out.shape)}, gate={tuple(gate.shape)}."
+                        )
+                    return self.wo(out * torch.sigmoid(gate))
+
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"{DISPLAY_NAME} attention patch failed in {module_name}: {exc}"
+                    ) from exc
+
+            return patched_forward
+
+        module.forward = types.MethodType(make_forward(original_forward, name), module)
+        installed += 1
+
+    if installed <= 0:
+        raise RuntimeError(
+            f"{DISPLAY_NAME} adapter patch failed: no compatible blocks.N.attn modules found."
+        )
+    return matched, installed, restored, patched_names
+
+
+def uses_reference_branch_kv() -> bool:
+    return False
+
+
+def describe_match(model_info: dict[str, Any]) -> str:
+    model_config_class = str(model_info.get("model_config_class", ""))
+    supported = ", ".join(sorted(SUPPORTED_MODEL_CONFIG_CLASSES))
+    return (
+        f"{DISPLAY_NAME}: model_config_class={model_config_class!r}, "
+        f"supported_classes={{{supported}}}"
+    )
+
+
+__all__ = [
+    "ARCHITECTURE",
+    "DISPLAY_NAME",
+    "CONFIG_KEY",
+    "SUPPORTED_MODEL_CONFIG_CLASSES",
+    "matches_model",
+    "is_model_identity",
+    "find_diffusion_model",
+    "default_runtime_cfg",
+    "axes_dims_from_head_dim",
+    "is_attention_name",
+    "is_main_block_attention_name",
+    "block_index_from_name",
+    "is_krea2_attention_module",
+    "is_joint_attention",
+    "prepare_reference_conditioning",
+    "patch_attention_modules",
+    "uses_reference_branch_kv",
+    "describe_match",
+]

--- a/workflows/workflow_Krea2_turbo.json
+++ b/workflows/workflow_Krea2_turbo.json
@@ -1,0 +1,1176 @@
+{
+  "id": "44259803-f9d6-4eb1-a94a-75b8213649d0",
+  "revision": 0,
+  "last_node_id": 636,
+  "last_link_id": 1568,
+  "nodes": [
+    {
+      "id": 617,
+      "type": "PreviewImage",
+      "pos": [
+        2439.855712890625,
+        1482.3291015625
+      ],
+      "size": [
+        554.5741577148438,
+        515.9512939453125
+      ],
+      "flags": {},
+      "order": 21,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1540
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.1",
+        "Node name for S&R": "PreviewImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 262,
+      "type": "VAEDecode",
+      "pos": [
+        2196.558349609375,
+        1538.8663330078125
+      ],
+      "size": [
+        140,
+        62.208309173583984
+      ],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 1568
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 507
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1540
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.0",
+        "Node name for S&R": "VAEDecode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 626,
+      "type": "Note",
+      "pos": [
+        810,
+        560
+      ],
+      "size": [
+        285.24835205078125,
+        126.58960723876953
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "Some additional methods not included in the paper, intended to further improve the results. These can be bypassed/removed."
+      ],
+      "color": "#c09430",
+      "bgcolor": "rgba(24,24,27,.9)"
+    },
+    {
+      "id": 265,
+      "type": "ImageScaleToTotalPixelsX",
+      "pos": [
+        240,
+        876.4774780273438
+      ],
+      "size": [
+        306.5982360839844,
+        214
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1539
+        },
+        {
+          "name": "width",
+          "shape": 7,
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "height",
+          "shape": 7,
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "links": [
+            749
+          ]
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            1560
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            1561
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "scale-image-to-total-pixels-advanced",
+        "ver": "dd4135f4ee6dcd71443e2935ceb5c037e3f23230",
+        "Node name for S&R": "ImageScaleToTotalPixelsX",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        1.05,
+        16,
+        "crop",
+        "lanczos"
+      ]
+    },
+    {
+      "id": 612,
+      "type": "LoadImage",
+      "pos": [
+        -115.60904693603516,
+        775.1746826171875
+      ],
+      "size": [
+        282.798828125,
+        314
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1539
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.1",
+        "Node name for S&R": "LoadImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "example.png",
+        "image"
+      ]
+    },
+    {
+      "id": 619,
+      "type": "Note",
+      "pos": [
+        240,
+        703.904052734375
+      ],
+      "size": [
+        306.5982360839844,
+        112.57343292236328
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "https://github.com/BigStationW/ComfyUi-Scale-Image-to-Total-Pixels-Advanced"
+      ],
+      "color": "#c09430",
+      "bgcolor": "rgba(24,24,27,.9)"
+    },
+    {
+      "id": 261,
+      "type": "VAELoader",
+      "pos": [
+        -102.46358489990234,
+        1440
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            507,
+            750
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.0",
+        "Node name for S&R": "VAELoader",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "qwen_image_vae.safetensors"
+      ]
+    },
+    {
+      "id": 618,
+      "type": "CLIPLoader",
+      "pos": [
+        -102.46358489990234,
+        1720.394287109375
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            1541,
+            1542
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.1",
+        "Node name for S&R": "CLIPLoader",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "qwen3vl_4b_fp8_scaled.safetensors",
+        "krea2",
+        "default"
+      ]
+    },
+    {
+      "id": 614,
+      "type": "Note",
+      "pos": [
+        240,
+        1304.4775390625
+      ],
+      "size": [
+        306.5982360839844,
+        116.00450134277344
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "You can create two CLIP Text Encode (one for the reference and one for the target), but personally, I find that using the target prompt for both yields better results."
+      ],
+      "color": "#c09430",
+      "bgcolor": "rgba(24,24,27,.9)"
+    },
+    {
+      "id": 634,
+      "type": "EmptyLatentImage",
+      "pos": [
+        1500,
+        1960
+      ],
+      "size": [
+        197.72500610351562,
+        106
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 1560
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 1561
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1562
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.25.0",
+        "Node name for S&R": "EmptyLatentImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.2.1"
+        }
+      },
+      "widgets_values": [
+        1024,
+        1024,
+        1
+      ]
+    },
+    {
+      "id": 259,
+      "type": "CLIPTextEncode",
+      "pos": [
+        240,
+        1156.4775390625
+      ],
+      "size": [
+        306.5982360839844,
+        88
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1542
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1564
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.0",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 333,
+      "type": "VAEEncode",
+      "pos": [
+        610,
+        1010
+      ],
+      "size": [
+        140,
+        46
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 749
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 750
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1526
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.0",
+        "Node name for S&R": "VAEEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 636,
+      "type": "ConditioningZeroOut",
+      "pos": [
+        1500,
+        1870
+      ],
+      "size": [
+        197.72500610351562,
+        26
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 1566
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1567
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.25.0",
+        "Node name for S&R": "ConditioningZeroOut",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.2.1"
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 635,
+      "type": "KSampler",
+      "pos": [
+        1850,
+        1740
+      ],
+      "size": [
+        270,
+        339.3125
+      ],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1565
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1563
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1567
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 1562
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1568
+          ]
+        }
+      ],
+      "title": "⚡KSampler⚡",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.25.1",
+        "Node name for S&R": "KSampler",
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "seed": true,
+            "steps": true,
+            "cfg": true,
+            "sampler_name": true,
+            "scheduler": true,
+            "denoise": true
+          },
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        811,
+        "increment",
+        8,
+        1,
+        "euler_ancestral",
+        "simple",
+        1
+      ],
+      "color": "#009933"
+    },
+    {
+      "id": 601,
+      "type": "UNETLoader",
+      "pos": [
+        -102.46358489990234,
+        1558
+      ],
+      "size": [
+        270,
+        102.3942642211914
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1558
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "UNETLoader",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "krea2_turbo.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 632,
+      "type": "UnofficialExtensions",
+      "pos": [
+        810,
+        740
+      ],
+      "size": [
+        285.24835205078125,
+        202
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "unofficial_extensions",
+          "type": "UNTWISTING_ROPE_EXTENSIONS",
+          "links": [
+            1557
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "untwistingrope",
+        "ver": "ec08050c160633dc890972120598e2912ce26870",
+        "Node name for S&R": "UnofficialExtensions",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        0,
+        "default",
+        0,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "id": 615,
+      "type": "Note",
+      "pos": [
+        810,
+        1010
+      ],
+      "size": [
+        289.0740051269531,
+        112.57343292236328
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "The quality of the style transfer depends largely on the quality of the RF inversion. These settings work well, but feel free to try other values."
+      ],
+      "color": "#c09430",
+      "bgcolor": "rgba(24,24,27,.9)"
+    },
+    {
+      "id": 603,
+      "type": "RFInversion",
+      "pos": [
+        810,
+        1180
+      ],
+      "size": [
+        273.3614807128906,
+        266
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1558
+        },
+        {
+          "name": "reference_latent",
+          "type": "LATENT",
+          "link": 1526
+        },
+        {
+          "name": "ref_conditioning",
+          "type": "CONDITIONING",
+          "link": 1564
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "links": [
+            1549
+          ]
+        },
+        {
+          "name": "rf_inversion",
+          "type": "LATENT",
+          "links": [
+            1550
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "untwistingrope",
+        "ver": "c9136fcced444ea84778a25a37a2b45371ea06a5",
+        "Node name for S&R": "RFInversion",
+        "aux_id": "BigStationW/ComfyUi-Untwisting-RoPE",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "flowturbo_pc",
+        0.5,
+        0,
+        0,
+        20,
+        false
+      ]
+    },
+    {
+      "id": 616,
+      "type": "Note",
+      "pos": [
+        1790,
+        1560
+      ],
+      "size": [
+        303.6560363769531,
+        116.00450134277344
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "recommend using only SDE samplers like er_sde or euler_ancestral, adding noise during the process really helps eliminate some transfer style artifacts."
+      ],
+      "color": "#c09430",
+      "bgcolor": "rgba(24,24,27,.9)"
+    },
+    {
+      "id": 633,
+      "type": "Note",
+      "pos": [
+        1140,
+        970
+      ],
+      "size": [
+        310,
+        150
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "for Krea2 :\n\n- blocks: 7-27\n- beta: 2 - 4 (2.5)\n- high_scale_start: 1.0 and 1.08 (1.04)\n- low_scale_end: 1.35 - 1.45 (1.40)\n- adain_strength: 0.75-1.0 \n- key_subspace_alignment: 0.00 - 0.05 (err lower)"
+      ],
+      "color": "#c09430",
+      "bgcolor": "rgba(24,24,27,.9)"
+    },
+    {
+      "id": 623,
+      "type": "UntwistingRoPE",
+      "pos": [
+        1136.9560546875,
+        1171.701171875
+      ],
+      "size": [
+        270,
+        270
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1549
+        },
+        {
+          "name": "rf_inversion",
+          "type": "LATENT",
+          "link": 1550
+        },
+        {
+          "name": "unofficial_extensions",
+          "shape": 7,
+          "type": "UNTWISTING_ROPE_EXTENSIONS",
+          "link": 1557
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "links": [
+            1565
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "untwistingrope",
+        "ver": "9fb6a19e82077dc54ddb120f202d474d01497cf7",
+        "Node name for S&R": "UntwistingRoPE",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        2.5,
+        1.04,
+        0,
+        1,
+        1.4,
+        0.85,
+        "7-27",
+        false
+      ]
+    },
+    {
+      "id": 607,
+      "type": "CLIPTextEncode",
+      "pos": [
+        887.940185546875,
+        1654.943115234375
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1541
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1563,
+            1566
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.0",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.2.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "a woman and a man on a small sailboat in rough seas"
+      ]
+    }
+  ],
+  "links": [
+    [
+      507,
+      261,
+      0,
+      262,
+      1,
+      "VAE"
+    ],
+    [
+      749,
+      265,
+      0,
+      333,
+      0,
+      "IMAGE"
+    ],
+    [
+      750,
+      261,
+      0,
+      333,
+      1,
+      "VAE"
+    ],
+    [
+      1526,
+      333,
+      0,
+      603,
+      1,
+      "LATENT"
+    ],
+    [
+      1539,
+      612,
+      0,
+      265,
+      0,
+      "IMAGE"
+    ],
+    [
+      1540,
+      262,
+      0,
+      617,
+      0,
+      "IMAGE"
+    ],
+    [
+      1541,
+      618,
+      0,
+      607,
+      0,
+      "CLIP"
+    ],
+    [
+      1542,
+      618,
+      0,
+      259,
+      0,
+      "CLIP"
+    ],
+    [
+      1549,
+      603,
+      0,
+      623,
+      0,
+      "MODEL"
+    ],
+    [
+      1550,
+      603,
+      1,
+      623,
+      1,
+      "LATENT"
+    ],
+    [
+      1557,
+      632,
+      0,
+      623,
+      2,
+      "UNTWISTING_ROPE_EXTENSIONS"
+    ],
+    [
+      1558,
+      601,
+      0,
+      603,
+      0,
+      "MODEL"
+    ],
+    [
+      1560,
+      265,
+      1,
+      634,
+      0,
+      "INT"
+    ],
+    [
+      1561,
+      265,
+      2,
+      634,
+      1,
+      "INT"
+    ],
+    [
+      1562,
+      634,
+      0,
+      635,
+      3,
+      "LATENT"
+    ],
+    [
+      1563,
+      607,
+      0,
+      635,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      1564,
+      259,
+      0,
+      603,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      1565,
+      623,
+      0,
+      635,
+      0,
+      "MODEL"
+    ],
+    [
+      1566,
+      607,
+      0,
+      636,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1567,
+      636,
+      0,
+      635,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      1568,
+      635,
+      0,
+      262,
+      0,
+      "LATENT"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.6727499949325698,
+      "offset": [
+        336.80954608198755,
+        -829.4092910421372
+      ]
+    },
+    "frontendVersion": "1.27.10",
+    "workflowRendererVersion": "LG",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true,
+    "ue_links": [],
+    "links_added_by_ue": []
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Implements single-stream MMDiT attention patching for Krea2 with GQA
head expansion, txtmlp-based imglen injection, and BHSD layout for
shared QKV effects.

adds minimal working example workflow for Krea2 in the same manner as other examples